### PR TITLE
Generated code in git differs when generating OS is Windows (carriage returns)

### DIFF
--- a/lib/hooks/forof.js
+++ b/lib/hooks/forof.js
@@ -70,11 +70,11 @@ var hooks = {".ForOfStatement": function (node) {
             ".iterator());      "
           ],
           "raw": [
-            "\r\n        ",
-            "\r\n        void function(_iterator){\r\n          try {\r\n            while (true) {\r\n              ",
-            "\r\n              ",
-            "\r\n            }\r\n          } catch (e) { if (e !== StopIteration ) throw e }\r\n        }.call(this, ",
-            ".iterator());\r\n      "
+            "\n        ",
+            "\n        void function(_iterator){\n          try {\n            while (true) {\n              ",
+            "\n              ",
+            "\n            }\n          } catch (e) { if (e !== StopIteration ) throw e }\n        }.call(this, ",
+            ".iterator());\n      "
           ]
         }, dec ? "var " + decs.join(", ") + ";" : "", left, body, right);
       }.bind(this);


### PR DESCRIPTION
I ran "sake compile:six" and it regenerated this file on Linux but without carriage returns.
