### PR TITLE
Register ".six" file extension + test.

### DIFF
--- a/lib/six.js
+++ b/lib/six.js
@@ -28,6 +28,12 @@ define(function (require, exports) {
   function nodes(src, options) {
     return dumpAst(src, options.verbose);
   }
+  if (require && require.extensions) {
+    require.extensions[".six"] = function (module, filename) {
+      var content = compile(fs.readFileSync(filename, "utf8"));
+      return module._compile(content, filename);
+    };
+  }
   Object.define(exports, {
     run: run,
     compile: compile,

--- a/src/six.six
+++ b/src/six.six
@@ -30,4 +30,12 @@ function nodes (src, options) {
   return dumpAst(src, options.verbose)
 }
 
+// Register .six exension with node
+if (require && require.extensions) {
+  require.extensions['.six'] = function(module, filename) {
+    var content = compile(fs.readFileSync(filename, 'utf8'));
+    return module._compile(content, filename);
+  };
+}
+
 Object.define(exports, { run, compile, nodes })

--- a/test/inc/mod.six
+++ b/test/inc/mod.six
@@ -1,0 +1,1 @@
+exports.number = () => 420

--- a/test/include.six
+++ b/test/include.six
@@ -1,0 +1,7 @@
+var expect = require("chai").expect;
+var six = require('../lib/six'); // this require enables the .six file extension
+
+describe('node six file extension include', function() {
+  var mod = require('./inc/mod')
+  expect(mod.number()).to.equal(420)
+})


### PR DESCRIPTION
So you can load ".six" files directly in nodejs after require("six") like for coffeescript.
