### PR TITLE
Preliminary support for exports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ import dirname from fs
 // Importing content direct from a file
 import local_function from "./local.js"
 
+// Export a function from a module.
+export function mod_func() { }
+
+// Export variables from a module.
+export var a = 400, b = {}
+
 ```
 
 ##Module Support

--- a/lib/command.js
+++ b/lib/command.js
@@ -119,35 +119,35 @@ define(function (require, exports) {
   var notSources = {};
   var watchers = {};
   var optionParser = null;
-  exports.run = function () {
-    parseOptions();
-    if (opts.nodejs)
-      return forkNode();
-    if (opts.help)
-      return usage();
-    if (opts.version)
-      return version();
-    if (opts.require)
-      loadRequires();
-    if (opts.interactive)
-      return require("./repl");
-    if (opts.watch && !fs.watch) {
-      return printWarn("The --watch feature depends on Node v0.6.0+. You are running " + process.version + ".");
-    }
-    if (opts.stdio)
-      return compileStdio();
-    if (opts.eval)
-      return compileScript(null, sources[0]);
-    if (!sources.length)
-      return require("./repl");
-    var literals = opts.run ? sources.splice(1) : [];
-    process.argv = process.argv.slice(0, 2).concat(literals);
-    process.argv[0] = "six";
-    process.execPath = require.main.filename;
-    sources.forEach(function (source) {
-      compilePath(source, true, path.normalize(source));
-    });
-  };
+  var run = exports.run = function () {
+      parseOptions();
+      if (opts.nodejs)
+        return forkNode();
+      if (opts.help)
+        return usage();
+      if (opts.version)
+        return version();
+      if (opts.require)
+        loadRequires();
+      if (opts.interactive)
+        return require("./repl");
+      if (opts.watch && !fs.watch) {
+        return printWarn("The --watch feature depends on Node v0.6.0+. You are running " + process.version + ".");
+      }
+      if (opts.stdio)
+        return compileStdio();
+      if (opts.eval)
+        return compileScript(null, sources[0]);
+      if (!sources.length)
+        return require("./repl");
+      var literals = opts.run ? sources.splice(1) : [];
+      process.argv = process.argv.slice(0, 2).concat(literals);
+      process.argv[0] = "six";
+      process.execPath = require.main.filename;
+      sources.forEach(function (source) {
+        compilePath(source, true, path.normalize(source));
+      });
+    };
   var compilePath = function (source, topLevel, base) {
     fs.stat(source, function (err, stats) {
       if (err && err.code !== "ENOENT")

--- a/lib/dumper.js
+++ b/lib/dumper.js
@@ -5,16 +5,15 @@ if (typeof exports === 'object' && typeof define !== 'function') {
 }
 define(function (require, exports) {
   var Tree = require("./esom/tree").Tree;
-  function dumpAst(src, includeRanges) {
-    var program = Tree.create(src);
-    if (!includeRanges) {
-      var delRange = function (node) {
-          delete node.ast.range;
-          node.children.forEach(delRange);
-        }.bind(this);
-      delRange(program.root);
-    }
-    return JSON.stringify(program.ast, null, 2);
-  }
-  exports.dumpAst = dumpAst;
+  var dumpAst = exports.dumpAst = function (src, includeRanges) {
+      var program = Tree.create(src);
+      if (!includeRanges) {
+        var delRange = function (node) {
+            delete node.ast.range;
+            node.children.forEach(delRange);
+          }.bind(this);
+        delRange(program.root);
+      }
+      return JSON.stringify(program.ast, null, 2);
+    };
 });

--- a/lib/esom/rel.js
+++ b/lib/esom/rel.js
@@ -4,7 +4,7 @@ if (typeof exports === 'object' && typeof define !== 'function') {
   };
 }
 define(function (require, exports) {
-  var Relatives = {
+  var Relatives = exports.Relatives = {
       first: function () {
         return this.children[0];
       },
@@ -29,5 +29,4 @@ define(function (require, exports) {
         return deepest;
       }
     };
-  exports.Relatives = Relatives;
 });

--- a/lib/esom/trav.js
+++ b/lib/esom/trav.js
@@ -84,7 +84,7 @@ define(function (require, exports) {
       };
       return Query;
     }();
-  var Traversal = {
+  var Traversal = exports.Traversal = {
       select: function (query, frags) {
         var results = [];
         var sels = query.match(queryPat);
@@ -170,5 +170,4 @@ define(function (require, exports) {
       }
     };
   Object.define(Traversal, require("./rel").Relatives);
-  exports.Traversal = Traversal;
 });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,12 +4,12 @@ if (typeof exports === 'object' && typeof define !== 'function') {
   };
 }
 define(function (require, exports) {
-  exports.extend = function (object, properties) {
-    var key, val;
-    for (key in properties) {
-      val = properties[key];
-      object[key] = val;
-    }
-    return object;
-  }.bind(this);
+  var extend = exports.extend = function (object, properties) {
+      var key, val;
+      for (key in properties) {
+        val = properties[key];
+        object[key] = val;
+      }
+      return object;
+    };
 });

--- a/lib/hooks/modules.js
+++ b/lib/hooks/modules.js
@@ -95,7 +95,7 @@ define(function (require, exports) {
           } else {
             from = from.context().body.node;
             var modNames = from.children.map(function (path) {
-                return path.context().name;
+                return path.name;
               }.bind(this));
             var modVarName = modNames.join("_");
             var modRoot = from.compile();
@@ -191,7 +191,7 @@ define(function (require, exports) {
           var exportee = node.context().declaration.context();
           switch (exportee.type) {
           case "FunctionDeclaration":
-            var name = exportee.id.context().name;
+            var name = exportee.id.name;
             return function (__quasi__) {
               var rawStrs = __quasi__["cooked"];
               var out = [];
@@ -233,7 +233,7 @@ define(function (require, exports) {
             var ret = "";
             exportee.declarations.children.forEach(function (value, idx) {
               var declaration = value.context();
-              var name = declaration.id.context().name;
+              var name = declaration.id.name;
               ret += function (__quasi__) {
                 var rawStrs = __quasi__["cooked"];
                 var out = [];
@@ -257,6 +257,61 @@ define(function (require, exports) {
             }.bind(this));
             return ret;
           case "ModuleDeclaration":
+            var from = exportee.from;
+            if (from) {
+              var name = exportee.id.name;
+              if (function (x, y) {
+                  return x === y ? x !== 0 || 1 / x === 1 / y : x !== x && y !== y;
+                }(from.type, "Literal")) {
+                var modRoot = from.value;
+                return function (__quasi__) {
+                  var rawStrs = __quasi__["cooked"];
+                  var out = [];
+                  for (var i = 0, k = -1, n = rawStrs.length; i < n;) {
+                    out[++k] = rawStrs[i];
+                    out[++k] = arguments[++i];
+                  }
+                  return out.join("");
+                }({
+                  "cooked": [
+                    "var ",
+                    " = exports.",
+                    " = require(\"",
+                    "\");"
+                  ],
+                  "raw": [
+                    "var ",
+                    " = exports.",
+                    " = require(\"",
+                    "\");"
+                  ]
+                }, name, name, modRoot);
+              } else {
+                var modRoot = fromcompile();
+                return function (__quasi__) {
+                  var rawStrs = __quasi__["cooked"];
+                  var out = [];
+                  for (var i = 0, k = -1, n = rawStrs.length; i < n;) {
+                    out[++k] = rawStrs[i];
+                    out[++k] = arguments[++i];
+                  }
+                  return out.join("");
+                }({
+                  "cooked": [
+                    "var ",
+                    " = exports.",
+                    " = ",
+                    ";"
+                  ],
+                  "raw": [
+                    "var ",
+                    " = exports.",
+                    " = ",
+                    ";"
+                  ]
+                }, name, name, modRoot);
+              }
+            }
           default:
             return node.context().declaration.compile();
           }

--- a/lib/hooks/modules.js
+++ b/lib/hooks/modules.js
@@ -73,7 +73,7 @@ define(function (require, exports) {
               return x === y ? x !== 0 || 1 / x === 1 / y : x !== x && y !== y;
             }(from.type, "Literal")) {
             var modRoot = from.value;
-            var modVarName = modRoot.replace("/", "_");
+            var modVarName = modRoot.replace(/[\/\.]/g, "_");
             modRoot = function (__quasi__) {
               var rawStrs = __quasi__["cooked"];
               var out = [];
@@ -184,6 +184,82 @@ define(function (require, exports) {
             }
           }.bind(this));
           return ret + ";";
+        }.bind(this);
+      }.bind(this),
+      ".ExportDeclaration": function (node) {
+        node.compile = function () {
+          var exportee = node.context().declaration.context();
+          switch (exportee.type) {
+          case "FunctionDeclaration":
+            var name = exportee.id.context().name;
+            return function (__quasi__) {
+              var rawStrs = __quasi__["cooked"];
+              var out = [];
+              for (var i = 0, k = -1, n = rawStrs.length; i < n;) {
+                out[++k] = rawStrs[i];
+                out[++k] = arguments[++i];
+              }
+              return out.join("");
+            }({
+              "cooked": [
+                "var ",
+                " = exports.",
+                " = function("
+              ],
+              "raw": [
+                "var ",
+                " = exports.",
+                " = function("
+              ]
+            }, name, name) + (exportee.params[0] ? exportee.params.compile() : "") + function (__quasi__) {
+              var rawStrs = __quasi__["cooked"];
+              var out = [];
+              for (var i = 0, k = -1, n = rawStrs.length; i < n;) {
+                out[++k] = rawStrs[i];
+                out[++k] = arguments[++i];
+              }
+              return out.join("");
+            }({
+              "cooked": [
+                ") ",
+                ";\n"
+              ],
+              "raw": [
+                ") ",
+                ";\\n"
+              ]
+            }, exportee.body.compile());
+          case "VariableDeclaration":
+            var ret = "";
+            exportee.declarations.children.forEach(function (value, idx) {
+              var declaration = value.context();
+              var name = declaration.id.context().name;
+              ret += function (__quasi__) {
+                var rawStrs = __quasi__["cooked"];
+                var out = [];
+                for (var i = 0, k = -1, n = rawStrs.length; i < n;) {
+                  out[++k] = rawStrs[i];
+                  out[++k] = arguments[++i];
+                }
+                return out.join("");
+              }({
+                "cooked": [
+                  "var ",
+                  " = exports.",
+                  " = "
+                ],
+                "raw": [
+                  "var ",
+                  " = exports.",
+                  " = "
+                ]
+              }, name, name) + (declaration.init ? declaration.init.compile() : "null") + ";\n";
+            }.bind(this));
+            return ret;
+          case "ModuleDeclaration":
+          default:
+            return node.context().declaration.compile();
+          }
         }.bind(this);
       }.bind(this)
     };

--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -7,22 +7,22 @@ define(function (require, exports) {
   require("./es6");
   var Tree = require("./esom/tree").Tree;
   var hooks = require("./hooks/base");
-  function rewrite(src, options) {
-    var program = Tree.create(src, options);
-    var selector, hook;
-    void function (_iterator) {
-      try {
-        while (true) {
-          selector = _iterator.next(), hook = selector.value, selector = selector.key;
-          program.root.select(selector).forEach(hook);
+  var rewrite = exports.rewrite = function (src, options) {
+      var program = Tree.create(src, options);
+      var selector, hook;
+      void function (_iterator) {
+        try {
+          while (true) {
+            selector = _iterator.next(), hook = selector.value, selector = selector.key;
+            program.root.select(selector).forEach(hook);
+          }
+        } catch (e) {
+          if (e !== StopIteration)
+            throw e;
         }
-      } catch (e) {
-        if (e !== StopIteration)
-          throw e;
-      }
-    }.call(this, hooks.iterator());
-    return program.compile();
-  }
+      }.call(this, hooks.iterator());
+      return program.compile();
+    };
   Object.define(Tree.prototype, {
     compile: function () {
       var src = this.raw();
@@ -65,5 +65,4 @@ define(function (require, exports) {
       }
       return Context;
     }();
-  exports.rewrite = rewrite;
 });

--- a/lib/sake.js
+++ b/lib/sake.js
@@ -42,23 +42,23 @@ define(function (require, exports) {
       return tasks[name].action(options);
     }
   });
-  exports.run = function () {
-    global.__originalDirname = fs.realpathSync(".");
-    process.chdir(sakefileDirectory(__originalDirname));
-    var args = process.argv.slice(2);
-    Six.run(fs.readFileSync("Sakefile").toString(), {filename: "Sakefile"});
-    oparse = new optparse.OptionParser(switches);
-    if (!args.length)
-      return printTasks();
-    try {
-      var options = oparse.parse(args);
-    } catch (e) {
-      return fatalError(e + "");
-    }
-    options.arguments.forEach(function (arg) {
-      invoke(arg);
-    });
-  };
+  var run = exports.run = function () {
+      global.__originalDirname = fs.realpathSync(".");
+      process.chdir(sakefileDirectory(__originalDirname));
+      var args = process.argv.slice(2);
+      Six.run(fs.readFileSync("Sakefile").toString(), {filename: "Sakefile"});
+      oparse = new optparse.OptionParser(switches);
+      if (!args.length)
+        return printTasks();
+      try {
+        var options = oparse.parse(args);
+      } catch (e) {
+        return fatalError(e + "");
+      }
+      options.arguments.forEach(function (arg) {
+        invoke(arg);
+      });
+    };
   var printTasks = function () {
     var relative = path.relative || path.resolve;
     var sakefilePath = path.join(relative(__originalDirname, process.cwd()), "Sakefile");

--- a/lib/six.js
+++ b/lib/six.js
@@ -8,29 +8,24 @@ define(function (require, exports) {
   var path = require("path");
   var rewrite = require("./rewriter").rewrite;
   var dumpAst = require("./dumper").dumpAst;
-  function run(code, options) {
-    var mainModule = require.main;
-    if (!options)
-      options = {};
-    mainModule.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : ".";
-    mainModule.moduleCache && (mainModule.moduleCache = {});
-    mainModule.paths = require("module")._nodeModulePaths(path.dirname(fs.realpathSync(options.filename)));
-    if (path.extname(mainModule.filename) !== ".six" || require.extensions) {
-      mainModule._compile(compile(code, options), mainModule.filename);
-    } else {
-      mainModule._compile(code, mainModule.filename);
-    }
-  }
-  function compile(src, options, callback) {
-    src = rewrite(src, options);
-    return src;
-  }
-  function nodes(src, options) {
-    return dumpAst(src, options.verbose);
-  }
-  Object.define(exports, {
-    run: run,
-    compile: compile,
-    nodes: nodes
-  });
+  var run = exports.run = function (code, options) {
+      var mainModule = require.main;
+      if (!options)
+        options = {};
+      mainModule.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : ".";
+      mainModule.moduleCache && (mainModule.moduleCache = {});
+      mainModule.paths = require("module")._nodeModulePaths(path.dirname(fs.realpathSync(options.filename)));
+      if (path.extname(mainModule.filename) !== ".six" || require.extensions) {
+        mainModule._compile(compile(code, options), mainModule.filename);
+      } else {
+        mainModule._compile(code, mainModule.filename);
+      }
+    };
+  var compile = exports.compile = function (src, options, callback) {
+      src = rewrite(src, options);
+      return src;
+    };
+  var nodes = exports.nodes = function (src, options) {
+      return dumpAst(src, options.verbose);
+    };
 });

--- a/src/command.six
+++ b/src/command.six
@@ -56,7 +56,7 @@ var optionParser = null
 // Run `six` by parsing passed options and determining what action to take.
 // Many flags cause us to divert before compiling anything. Flags passed after
 // `--` will be passed verbatim to your script as arguments in `process.argv`
-exports.run = function() {
+export function run() {
   parseOptions()
   if ( opts.nodejs ) return forkNode()
   if ( opts.help ) return usage()

--- a/src/dumper.six
+++ b/src/dumper.six
@@ -1,6 +1,6 @@
 import Tree from "./esom/tree"
 
-function dumpAst(src, includeRanges) {
+export function dumpAst(src, includeRanges) {
   var program = Tree.create(src)
 
   if (! includeRanges) {
@@ -13,5 +13,3 @@ function dumpAst(src, includeRanges) {
 
   return JSON.stringify(program.ast, null, 2)
 }
-
-exports.dumpAst = dumpAst

--- a/src/esom/rel.six
+++ b/src/esom/rel.six
@@ -1,4 +1,4 @@
-var Relatives = {
+export var Relatives = {
 
   first()  this.children[ 0 ],
   last()   this.children[ this.children.length -1 ],
@@ -25,5 +25,3 @@ var Relatives = {
   }
 
 }
-
-exports.Relatives = Relatives

--- a/src/esom/trav.six
+++ b/src/esom/trav.six
@@ -95,7 +95,7 @@ class Query {
 
 }
 
-var Traversal = {
+export var Traversal = {
 
   select(query, frags) {
     var results = []
@@ -179,5 +179,3 @@ var Traversal = {
 }
 
 Object.define(Traversal, require("./rel").Relatives)
-
-exports.Traversal = Traversal

--- a/src/filters.six
+++ b/src/filters.six
@@ -1,4 +1,4 @@
-var filters = exports.filters = {
+export var filters = {
   egal: require("./filters/egal").filter,
   quasi: require("./filters/quasi").filter,
   'class': require("./filters/class").filter,

--- a/src/helpers.six
+++ b/src/helpers.six
@@ -1,4 +1,4 @@
-exports.extend = (object, properties) => {
+export function extend(object, properties) {
   var key, val
   for (key in properties) {
     val = properties[key]

--- a/src/hooks/modules.six
+++ b/src/hooks/modules.six
@@ -32,7 +32,7 @@ var hooks = {
       if (from.type is 'Literal') {
         // import directly from file
         var modRoot = from.value
-        var modVarName = modRoot.replace('/', '_')
+        var modVarName = modRoot.replace(/[\/\.]/g, '_')
         modRoot = `require("${modRoot}")`
       }
       else {
@@ -69,6 +69,33 @@ var hooks = {
       })
 
       return ret + ";";
+    }
+  },
+  ".ExportDeclaration": node => {
+    node.compile = () => {
+      var exportee = node.context().declaration.context()
+      switch (exportee.type) {
+        case "FunctionDeclaration":
+          var name = exportee.id.context().name
+          // test params[0] as when empty it is an array, otherwise an object
+          return `var ${name} = exports.${name} = function(` +
+           (exportee.params[0] ? exportee.params.compile() : '') +
+           `) ${exportee.body.compile()};\n`
+        case "VariableDeclaration":
+          var ret = ''
+          exportee.declarations.children.forEach((value, idx) => {
+            var declaration = value.context()
+            var name = declaration.id.context().name
+            ret += `var ${name} = exports.${name} = ` +
+              (declaration.init ? declaration.init.compile() : 'null') + ";\n"
+          })
+          return ret
+        case "ModuleDeclaration":
+          // TODO
+        default:
+          // should be unreachable but fallthrough in case the standard changes
+          return node.context().declaration.compile()
+      }
     }
   }
 }

--- a/src/hooks/modules.six
+++ b/src/hooks/modules.six
@@ -38,7 +38,7 @@ var hooks = {
       else {
         // the only other valid text here is a namespace path
         from = from.context().body.node
-        var modNames = from.children.map(path => path.context().name)
+        var modNames = from.children.map(path => path.name)
         var modVarName = modNames.join("_")
         var modRoot = from.compile()
       }
@@ -76,7 +76,7 @@ var hooks = {
       var exportee = node.context().declaration.context()
       switch (exportee.type) {
         case "FunctionDeclaration":
-          var name = exportee.id.context().name
+          var name = exportee.id.name
           // test params[0] as when empty it is an array, otherwise an object
           return `var ${name} = exports.${name} = function(` +
            (exportee.params[0] ? exportee.params.compile() : '') +
@@ -85,12 +85,25 @@ var hooks = {
           var ret = ''
           exportee.declarations.children.forEach((value, idx) => {
             var declaration = value.context()
-            var name = declaration.id.context().name
+            var name = declaration.id.name
             ret += `var ${name} = exports.${name} = ` +
               (declaration.init ? declaration.init.compile() : 'null') + ";\n"
           })
           return ret
         case "ModuleDeclaration":
+          var from = exportee.from
+          if (from) {
+            var name = exportee.id.name
+            if (from.type is 'Literal') {
+              // import directly from file
+              var modRoot = from.value
+              return `var ${name} = exports.${name} = require("${modRoot}");`
+            }
+            else {
+              var modRoot = fromcompile()
+              return `var ${name} = exports.${name} = ${modRoot};`
+            }
+          }
           // TODO
         default:
           // should be unreachable but fallthrough in case the standard changes

--- a/src/rewriter.six
+++ b/src/rewriter.six
@@ -3,7 +3,7 @@ require("./es6")
 import Tree from "./esom/tree"
 module hooks = "./hooks/base"
 
-function rewrite(src, options) {
+export function rewrite(src, options) {
   var program = Tree.create(src, options)
 
   for(var { selector: key, hook: value } of hooks) {
@@ -62,5 +62,3 @@ class Context {
   }
 
 }
-
-exports.rewrite = rewrite

--- a/src/sake.six
+++ b/src/sake.six
@@ -54,7 +54,7 @@ helpers.extend(global, {
 // asynchrony may cause tasks to execute in a different order than you'd expect.
 // If no tasks are passed, print the help screen. Keep a reference to the
 // original directory name, when running Sake tasks from subdirectories.
-exports.run = function(){
+export function run() {
   global.__originalDirname = fs.realpathSync('.')
   process.chdir(sakefileDirectory(__originalDirname))
   var args = process.argv.slice(2)

--- a/src/six.six
+++ b/src/six.six
@@ -5,7 +5,7 @@ module path = "path"
 import rewrite from "./rewriter"
 import dumpAst from "./dumper"
 
-function run (code, options) {
+export function run (code, options) {
   var mainModule = require.main
 
   if(!options) options = {}
@@ -21,13 +21,11 @@ function run (code, options) {
   }
 }
 
-function compile (src, options, callback) {
+export function compile (src, options, callback) {
   src = rewrite(src, options)
   return src
 }
 
-function nodes (src, options) {
+export function nodes (src, options) {
   return dumpAst(src, options.verbose)
 }
-
-Object.define(exports, { run, compile, nodes })

--- a/test/module.js
+++ b/test/module.js
@@ -30,4 +30,33 @@ describe('import statement', function() {
     eval(result)
     expect(n).to.equal(420)
   })
+
+  it("alias a module alias to a subsequent alias", function(){
+    var src = "module dance = './inc/magic'; module bon = dance; var n = bon.number()"
+    var result = compile(src)
+    eval(result)
+    expect(n).to.equal(420)
+  })
+
+  it("export a function from a module", function(){
+    var src = "export function add400(a) { return a + 400; }"
+    eval(six.compile(src))
+    var n = exports.add400(20)
+    expect(n).to.equal(420)
+    exports = {}
+  })
+
+  it("export a variable from a module", function(){
+    var src = "export var n = 420"
+    eval(six.compile(src))
+    expect(exports.n).to.equal(420)
+    exports = {}
+  })
+
+  it("export variables from a module", function(){
+    var src = "export var a = 420, b = 400, c = 20"
+    eval(six.compile(src))
+    expect(exports.a).to.equal(exports.b + exports.c)
+    exports = {}
+  })
 });

--- a/test/module.js
+++ b/test/module.js
@@ -59,4 +59,11 @@ describe('import statement', function() {
     expect(exports.a).to.equal(exports.b + exports.c)
     exports = {}
   })
+
+  it("export module alias from a module", function(){
+    var src = "export module mag = './inc/magic';"
+    eval(six.compile(src))
+    expect(exports.mag.number()).to.equal(420)
+    exports = {}
+  })
 });


### PR DESCRIPTION
There are some points that don't work such as re-assignments to exported variables.

``` javascript
export var a = 42
a = 43 // exported version will still be 42

export function c() { return 1 }
c = function() { return 2 }  // 1 will still be in exported version

export o = {}
o.a 420 // this is fine, changing a type by reference
```

In order to support those instead of

``` javascript
var exported = exported = function {}
exported('blah')
```

You'd have to modify the entire source tree for that scope to replace all references to "exported" to "exports.exported". That's the only way you'd be able to make changes to non-reference types visible.

``` javascript
// compiled from
// export function exported(a) {}
// exported('blah')
var exported = exported = function(a) {}
exports.exported('blah')
```
