### PR TITLE
Support plain export statement.

### DIFF
--- a/lib/hooks/modules.js
+++ b/lib/hooks/modules.js
@@ -188,7 +188,35 @@ define(function (require, exports) {
       }.bind(this),
       ".ExportDeclaration": function (node) {
         node.compile = function () {
-          var exportee = node.context().declaration.context();
+          var declaration = node.context().declaration;
+          if (!declaration) {
+            var ret = "";
+            node.context().specifiers.node.children.forEach(function (value) {
+              var name = value.context().id.name;
+              ret += function (__quasi__) {
+                var rawStrs = __quasi__["cooked"];
+                var out = [];
+                for (var i = 0, k = -1, n = rawStrs.length; i < n;) {
+                  out[++k] = rawStrs[i];
+                  out[++k] = arguments[++i];
+                }
+                return out.join("");
+              }({
+                "cooked": [
+                  "exports.",
+                  " = ",
+                  ";"
+                ],
+                "raw": [
+                  "exports.",
+                  " = ",
+                  ";"
+                ]
+              }, name, name);
+            }.bind(this));
+            return ret;
+          }
+          var exportee = declaration.context();
           switch (exportee.type) {
           case "FunctionDeclaration":
             var name = exportee.id.name;

--- a/src/hooks/modules.six
+++ b/src/hooks/modules.six
@@ -73,7 +73,17 @@ var hooks = {
   },
   ".ExportDeclaration": node => {
     node.compile = () => {
-      var exportee = node.context().declaration.context()
+      var declaration = node.context().declaration
+      if (! declaration) {
+        var ret = ''
+        node.context().specifiers.node.children.forEach(value => {
+          var name = value.context().id.name
+          ret += `exports.${name} = ${name};`
+        })
+        return ret
+      }
+
+      var exportee = declaration.context()
       switch (exportee.type) {
         case "FunctionDeclaration":
           var name = exportee.id.name

--- a/test/module.js
+++ b/test/module.js
@@ -66,4 +66,11 @@ describe('import statement', function() {
     expect(exports.mag.number()).to.equal(420)
     exports = {}
   })
+
+  it("export a predeclared symbol", function(){
+    var src = "var lovely = 'kitten'; export lovely"
+    eval(six.compile(src))
+    expect(exports.lovely).to.equal('kitten')
+    exports = {}
+  })
 });


### PR DESCRIPTION
Supports:

``` javascript
var a = "hey", b = 420;
export a, b
```
