### PR TITLE
20% compiler speedup by reducing number of tree traversals and avoiding node children array clones..

### DIFF
--- a/lib/esom/tree.js
+++ b/lib/esom/tree.js
@@ -81,6 +81,18 @@ define(function (require, exports) {
           }
         }.bind(this));
       };
+      Tree.prototype.visitByType = function (typeCallbacks) {
+        this.children.forEach(function (child) {
+          if (!child.ast) {
+            return;
+          }
+          var callback = typeCallbacks[child.ast.type];
+          if (callback) {
+            callback(child);
+          }
+          child.visitByType(typeCallbacks);
+        }.bind(this));
+      };
       Tree.prototype.raw = function () {
         return this.source.substring(this.ast.range[0], this.ast.range[1]);
       };

--- a/lib/esom/tree.js
+++ b/lib/esom/tree.js
@@ -56,7 +56,7 @@ define(function (require, exports) {
             return parent;
           },
           get children() {
-            return children.slice(0);
+            return children;
           },
           unshift: function (node) {
             children.unshift(node);

--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -7,6 +7,27 @@ define(function (require, exports) {
   require("./es6");
   var Tree = require("./esom/tree").Tree;
   var hooks = require("./hooks/base");
+  var visitors = {};
+  function optimizeHooks() {
+    var sels = Object.keys(hooks);
+    var optimizable = /^\.[a-zA-Z]+$/;
+    var sel;
+    void function (_iterator) {
+      try {
+        while (true) {
+          sel = _iterator.next();
+          if (optimizable.exec(sel)) {
+            visitors[sel.substring(1)] = hooks[sel];
+            delete hooks[sel];
+          }
+        }
+      } catch (e) {
+        if (e !== StopIteration)
+          throw e;
+      }
+    }.call(this, sels.iterator());
+  }
+  optimizeHooks();
   var rewrite = exports.rewrite = function (src, options) {
       var program = Tree.create(src, options);
       var selector, hook;
@@ -21,6 +42,7 @@ define(function (require, exports) {
             throw e;
         }
       }.call(this, hooks.iterator());
+      program.root.visitByType(visitors);
       return program.compile();
     };
   Object.define(Tree.prototype, {

--- a/src/esom/tree.six
+++ b/src/esom/tree.six
@@ -43,7 +43,7 @@ class Tree {
     Object.define(node, {
       get ast() { return base.ast },
       get parent() { return parent },
-      get children() { return children.slice(0) },
+      get children() { return children },
       unshift(node) { children.unshift(node) },
       push(node) { children.push(node) }
     })

--- a/src/esom/tree.six
+++ b/src/esom/tree.six
@@ -64,6 +64,21 @@ class Tree {
     })
   }
 
+  visitByType (typeCallbacks) {
+    this.children.forEach(child => {
+      if (! child.ast) {
+        return
+      }
+
+      var callback = typeCallbacks[child.ast.type]
+      if (callback) {
+        callback(child)
+      }
+
+      child.visitByType(typeCallbacks)
+    })
+  }
+
   raw() { return this.source.substring(this.ast.range[0], this.ast.range[1]) }
   isRoot() { return this.parent === this.root }
   path() { return this.isRoot() ? "" : this.parent.path + "." + this.key }

--- a/src/rewriter.six
+++ b/src/rewriter.six
@@ -3,12 +3,31 @@ require("./es6")
 import Tree from "./esom/tree"
 module hooks = "./hooks/base"
 
+// A cache of hooks that can be run in a single pass.
+var visitors = {}
+
+// Push applicable hooks into visitor pass.
+function optimizeHooks() {
+  var sels = Object.keys(hooks)
+  var optimizable = /^\.[a-zA-Z]+$/
+  for (var sel of sels) {
+    if (optimizable.exec(sel)) {
+      visitors[sel.substring(1)] = hooks[sel]
+      delete hooks[sel]
+    }
+  }
+}
+
+optimizeHooks()
+
 export function rewrite(src, options) {
   var program = Tree.create(src, options)
 
   for(var { selector: key, hook: value } of hooks) {
     program.root.select(selector).forEach(hook)
   }
+
+  program.root.visitByType(visitors)
 
   return program.compile()
 }


### PR DESCRIPTION
This reduces the six bootstrap-compilation time for me from 5.7s to 4.8s.

I was expecting a greater speedup, but ah well.. it's almost a 20% speedup.

There may be a better place to put the code but I believe the general principle and algorithms are sound.

Let me  know how you want to proceed.
