### PR TITLE
Some first pass speed optimizations

### DIFF
--- a/lib/esom/tree.js
+++ b/lib/esom/tree.js
@@ -11,18 +11,10 @@ define(function (require, exports) {
       function Tree(source, options) {
         var ast = parse(source, {range: true});
         var children = [];
-        Object.define(this, {
-          root: this,
-          get source() {
-            return source;
-          },
-          get ast() {
-            return ast;
-          },
-          get children() {
-            return children;
-          }
-        });
+        this.root = this;
+        this.source = source;
+        this.ast = ast;
+        this.children = children;
         children.push(this.create({
           ast: ast,
           key: "root",
@@ -48,16 +40,10 @@ define(function (require, exports) {
             children.push(node.create(child));
           }
         }.bind(this));
+        node.ast = base.ast;
+        node.parent = parent;
+        node.children = children;
         Object.define(node, {
-          get ast() {
-            return base.ast;
-          },
-          get parent() {
-            return parent;
-          },
-          get children() {
-            return children;
-          },
           unshift: function (node) {
             children.unshift(node);
           },

--- a/src/esom/tree.six
+++ b/src/esom/tree.six
@@ -9,14 +9,12 @@ class Tree {
     var ast = parse(source, { range: true, })
     var children = []
 
-    Object.define(this, {
-      root: this,
-      get source() { return source },
-      get ast() { return ast },
-      get children() {return children}
-    })
+    this.root = this
+    this.source = source
+    this.ast = ast
+    this.children = children
 
-     children.push(this.create({ ast, key: 'root', type: 'Node' }))
+    children.push(this.create({ ast, key: 'root', type: 'Node' }))
 
     var node = children[0]
     node.global = options && options.global
@@ -40,10 +38,11 @@ class Tree {
       }
     })
 
+    node.ast = base.ast
+    node.parent = parent
+    node.children = children
+
     Object.define(node, {
-      get ast() { return base.ast },
-      get parent() { return parent },
-      get children() { return children },
       unshift(node) { children.unshift(node) },
       push(node) { children.push(node) }
     })


### PR DESCRIPTION
No longer benefiting from using accessors in nodes, now assigning them as references. Seeing above 30% speed improvement!
